### PR TITLE
some minor general cleanup

### DIFF
--- a/kernel/api/chario.c
+++ b/kernel/api/chario.c
@@ -1,4 +1,5 @@
 #include<stdint.h>
+#include<stdbool.h>
 #include<ptrdef.h>
 #include<bios/io.h>
 #include<api/stack.h>
@@ -31,11 +32,11 @@ static int handle_control_c(char key) {
     return 0;
 }
 
-static unsigned int status() {
+static unsigned int status(void) {
     unsigned int key;
     char ascii;
 
-    while (1) {
+    while (true) {
         key = bios_status();
         ascii = key & 0xFF;
 
@@ -51,10 +52,10 @@ static unsigned int status() {
     return key;
 }
 
-static char getchar() {
+static char getchar(void) {
     char key;
 
-    while (1) {
+    while (true) {
         key = bios_getchar();
 
         /* check for ctrl+c, ctrl+p or ctrl+s */
@@ -154,7 +155,7 @@ void puts(void) {
     }
 }
 
-static int add_char_to_buffer (unsigned char key, unsigned char *buffer, uint8_t newlen, uint8_t *newpos) {
+static int add_char_to_buffer (unsigned char key, char *buffer, uint8_t newlen, uint8_t *newpos) {
     if (*newpos < newlen - 1) {
         /* echo keys back */
         if ((key < ' ') && (key != '\t')) {
@@ -175,7 +176,7 @@ static int add_char_to_buffer (unsigned char key, unsigned char *buffer, uint8_t
     }
 }
 
-static uint8_t skip_to_char (const unsigned char far *oldbuf, uint8_t oldlen, uint8_t oldpos) {
+static uint8_t skip_to_char (const char far *oldbuf, uint8_t oldlen, uint8_t oldpos) {
     char key;
     int count;
 
@@ -207,11 +208,11 @@ void gets(void) {
     /* set starting position */
     unsigned int initpos = linepos;
     uint8_t newpos = 0, oldpos = 0;
-    int insert = 0;
+    bool insert = false;
     /* point original input buffer to start of page */
     oldbuf += 2;
 
-    while (1) {
+    while (true) {
         /* get next key including extended key code */
         unsigned int key = getchar();
         if (!key) {
@@ -280,7 +281,8 @@ void gets(void) {
                 while (linepos != initpos)
                     kputchar('\b');
                 kputchar('\n');
-                insert = newpos = oldpos = 0;
+                insert = false;
+                newpos = oldpos = 0;
                 break;
 
             case 0x52<<8: /* insert */
@@ -330,7 +332,8 @@ void gets(void) {
                 while (linepos != initpos)
                     kputchar('\b');
                 kputchar('\n');
-                insert = newpos = oldpos = 0;
+                insert = false;
+                newpos = oldpos = 0;
                 break;
 
             default:

--- a/kernel/api/exep.h
+++ b/kernel/api/exep.h
@@ -2,22 +2,22 @@
 #define __EXEP_H__
 
 enum disk_rw_t {
-    read = 0, write = 1
+    read, write
 };
 
 enum disk_location_t {
-    reserved = 0, fat = 1, directory = 2, data = 3
+    reserved, fat, directory, data
 };
 
 enum error_code_t {
-    write_protect = 0, not_ready = 2, data_error = 4, seek_error = 6, sector_not_found = 8, write_fault = 10, general_error = 12
+    write_protect, not_ready = 2, data_error = 4, seek_error = 6, sector_not_found = 8, write_fault = 10, general_error = 12
 };
 
 enum error_response_t {
-    ignore = 0, retry = 1, abort = 2
+    ignore, retry, abort
 };
 
 enum error_response_t throw_disk_error(uint8_t, enum disk_rw_t, enum disk_location_t, enum error_code_t);
-enum error_response_t throw_fat_error();
+enum error_response_t throw_fat_error(void);
 
 #endif

--- a/kernel/bios/io.h
+++ b/kernel/bios/io.h
@@ -5,7 +5,7 @@ void bios_init(void);
 
 void bios_putchar(char);
 char bios_getchar(void);
-unsigned int bios_status();
+unsigned int bios_status(void);
 void bios_flush(void);
 void bios_com_putchar(unsigned int, char);
 char bios_com_getchar(unsigned int);

--- a/kernel/lib/alloc.c
+++ b/kernel/lib/alloc.c
@@ -1,3 +1,6 @@
+#include<stddef.h>
+#include<stdint.h>
+#include<stdbool.h>
 #include<ptrdef.h>
 #include<lib/klib.h>
 #include<lib/alloc.h>
@@ -5,14 +8,14 @@
 extern symbol bss_end;
 static unsigned int memory_base;
 static unsigned int memory_end;
-static int inited = 0;
+static bool inited = false;
 static char memerror[] = "\r\nMemory allocation error\r\n";
 
 /* DOS-style MCB */
 __attribute__((packed)) struct mcb_t {
     char type;
     unsigned int owner;
-    unsigned int size;
+    segment_t size;
     char reserved[11];
 };
 
@@ -20,7 +23,7 @@ __attribute__((packed)) struct mcb_t {
 
 void init_knalloc(void) {
     /* get first paragraph after kernel segment */
-    memory_base = PARA((unsigned int)bss_end);
+    memory_base = PARA((uintptr_t)bss_end);
 
     /* get first paragraph after conventional memory */
     asm ("int $0x12" : "=a" (memory_end));
@@ -30,8 +33,8 @@ void init_knalloc(void) {
 }
 
 /* allocates a memory chunk inside the kernel segment during initialization */
-void *knalloc(unsigned int size) {
-    unsigned int i;
+void *knalloc(size_t size) {
+    size_t i;
     char *ptr;
 
     /* make sure far memory manager not initialized */
@@ -58,20 +61,21 @@ void init_kfalloc(void) {
     root_chunk->owner = 0;
     root_chunk->size = memory_end - (memory_base + HEAP_CHUNK_SIZE);
 
-    inited=1;
+    inited = true;
     return;
 }
 
-void far *kfalloc(unsigned long size, unsigned int owner) {
+void far *kfalloc(farsize_t size, unsigned int owner) {
     /* search for a big enough, free heap chunk */
     struct mcb_t far *heap_chunk = FARPTR(memory_base,0);
     struct mcb_t far *new_chunk;
-    unsigned long heap_chunk_ptr;
+    uintfar_t heap_chunk_ptr;
     char far *area;
-    unsigned int i,j;
+    segment_t i;
+    size_t j;
 
     /* convert size into paragraphs */
-    unsigned int paras = PARA(size);
+    segment_t paras = PARA(size);
 
     for (;;) {
         if (heap_chunk->type!='M' && heap_chunk->type!='Z')
@@ -114,16 +118,16 @@ void far *kfalloc(unsigned long size, unsigned int owner) {
             areaseg[i]=0;
             j++;
         } while (j);
-        areaseg += (unsigned long)FARPTR(256,0);
+        areaseg += (uintfar_t)FARPTR(256,0);
     }
-    for (i = 0; i < (size & 0xFFFF); i++)
-        areaseg[i] = 0;
+    for (j = 0; j < (size & 0xFFFF); j++)
+        areaseg[j] = 0;
 
     return area;
 }
 
 void kffree(void far *addr) {
-    unsigned int heap_chunk_ptr = SEGMENTOF(addr);
+    segment_t heap_chunk_ptr = SEGMENTOF(addr);
     far struct mcb_t *heap_chunk, *next_chunk, *prev_chunk;
 
     heap_chunk_ptr -= HEAP_CHUNK_SIZE;
@@ -165,8 +169,8 @@ void kffree(void far *addr) {
     return;
 }
 
-void far *kfrealloc(void far *addr, unsigned long new_size) {
-    unsigned int heap_chunk_ptr = SEGMENTOF(addr);
+void far *kfrealloc(void far *addr, farsize_t new_size) {
+    segment_t heap_chunk_ptr = SEGMENTOF(addr);
     struct mcb_t far *heap_chunk;
     char far *new_ptr;
 
@@ -185,7 +189,7 @@ void far *kfrealloc(void far *addr, unsigned long new_size) {
         return (void far *)0;
 
     /* convert size to paragraphs */
-    unsigned int paras = PARA(new_size);
+    segment_t paras = PARA(new_size);
 
     if (heap_chunk->size > paras)
         kfmemcpy(new_ptr, addr, paras << 4);

--- a/kernel/lib/alloc.h
+++ b/kernel/lib/alloc.h
@@ -2,12 +2,12 @@
 #define __ALLOC_H__
 
 void init_knalloc(void);
-void *knalloc(unsigned int);
+void *knalloc(size_t);
 
 void init_kfalloc(void);
-void far *kfalloc(unsigned long, unsigned int);
+void far *kfalloc(farsize_t, unsigned int);
 void kffree(void far *);
-void far *kfrealloc(void far *, unsigned long);
+void far *kfrealloc(void far *, farsize_t);
 
 typedef char symbol[];
 

--- a/kernel/ptrdef.h
+++ b/kernel/ptrdef.h
@@ -2,10 +2,14 @@
 #define __PTRDEF_H__
 
 #define far __far
-#define SEGMENTOF(x) ((unsigned int)((unsigned long)(x) >> 16))
-#define OFFSETOF(x) ((unsigned int)((x) & 0xFFFF))
-#define FARPTR(x,y) ((void far *)(((unsigned long)(x) << 16) + (y)))
+#define SEGMENTOF(x) ((segment_t)((uintfar_t)(x) >> 16))
+#define OFFSETOF(x) ((uintptr_t)((x) & 0xFFFF))
+#define FARPTR(x,y) ((void far *)(((uintfar_t)(x) << 16) + (y)))
 #define PARA(x) (((x) & 0xF) == 0 ? (x)>>4 : ((x)>>4) + 1)
+
+typedef uint16_t segment_t;
+typedef uint32_t uintfar_t;
+typedef uint32_t farsize_t;
 
 extern void far ** const ivt;
 extern void * const nullptr;


### PR DESCRIPTION
* Replaced accidental `()` by proper `(void)` declarations.
* Added `uintfar_t`, `farsize_t` and `segment_t` to make the semantics of certain variables explicit.
* Used `stdbool.h` macros.
* Removed redundant enum constant specification.